### PR TITLE
Maximum drama

### DIFF
--- a/dramatic.py
+++ b/dramatic.py
@@ -36,7 +36,7 @@ import sys
 from textwrap import dedent
 from time import perf_counter, sleep
 
-__version__ = "0.3.0"
+__version__ = "0.4.0.alpha1"
 __all__ = []  # Disable "from dramatic import *"
 _DEFAULT_SPEED = 75
 

--- a/dramatic.py
+++ b/dramatic.py
@@ -29,7 +29,9 @@ from contextlib import ContextDecorator, ExitStack
 from fractions import Fraction
 from importlib.util import find_spec
 from io import TextIOWrapper
+from pathlib import Path
 import runpy
+from site import getusersitepackages
 import sys
 from textwrap import dedent
 from time import perf_counter, sleep
@@ -164,6 +166,16 @@ def stop():
 def parse_arguments():
     parser = ArgumentParser(description="Run Python, but dramatically", add_help=False)
     parser.add_argument(
+        "--max-drama",
+        action="store_true",
+        help="Monkey patch Python to make ALL Python programs to be dramatic",
+    )
+    parser.add_argument(
+        "--min-drama",
+        action="store_true",
+        help="Undo --max-drama",
+    )
+    parser.add_argument(
         "-m",
         metavar="mod",
         dest="module",
@@ -198,6 +210,38 @@ def repl_banner():
 def main():
     args, unknown = parse_arguments()
     start(speed=args.speed)
+
+    # Monkey patch Python so all Python programs to print dramatically
+    if args.max_drama:
+        site_packages = Path(getusersitepackages())
+        dramatic_py = site_packages / "_dramatic.py"
+        dramatic_pth = site_packages / "dramatic.pth"
+        print("This will cause all Python programs to run dramatically.")
+        print("Running --min-drama will undo this operation.")
+        if input("Are you sure? [y/N] ").casefold() != "y":
+            sys.exit("Okay. No drama.")
+        site_packages.mkdir(parents=True, exist_ok=True)
+        dramatic_py.write_text(Path(__file__).read_text())
+        print(f"Wrote file {dramatic_py}")
+        dramatic_pth.write_text("import _dramatic; _dramatic.start()\n")
+        print(f"Wrote file {dramatic_pth}")
+        sys.exit(0)
+
+    # Un-monkey patch Python to stop printing dramatically by default
+    if args.min_drama:
+        site_packages = Path(getusersitepackages())
+        dramatic_py = site_packages / "_dramatic.py"
+        dramatic_pth = site_packages / "dramatic.pth"
+        try:
+            dramatic_pth.unlink()
+        except FileNotFoundError:
+            print(f"File not found: {dramatic_pth}")
+        else:
+            print(f"Deleted file {dramatic_pth}")
+        dramatic_py.unlink()
+        print(f"Deleted file {dramatic_py}")
+        print("No drama.")
+        sys.exit(0)
 
     # Run the given Python module
     if args.module:

--- a/dramatic.py
+++ b/dramatic.py
@@ -168,7 +168,7 @@ def parse_arguments():
     parser.add_argument(
         "--max-drama",
         action="store_true",
-        help="Monkey patch Python to make ALL Python programs to be dramatic",
+        help="Monkey patch Python so ALL programs run dramatically",
     )
     parser.add_argument(
         "--min-drama",
@@ -238,8 +238,12 @@ def main():
             print(f"File not found: {dramatic_pth}")
         else:
             print(f"Deleted file {dramatic_pth}")
-        dramatic_py.unlink()
-        print(f"Deleted file {dramatic_py}")
+        try:
+            dramatic_py.unlink()
+        except FileNotFoundError:
+            print(f"File not found: {dramatic_py}")
+        else:
+            print(f"Deleted file {dramatic_py}")
         print("No drama.")
         sys.exit(0)
 

--- a/readme.md
+++ b/readme.md
@@ -229,7 +229,10 @@ No drama.
 Other Features
 --------------
 
-Pressing `Ctrl-C` while text is printing dramatically will cause the remaining text to print immediately.
+Other features of note:
+
+- Pressing `Ctrl-C` while text is printing dramatically will cause the remaining text to print immediately.
+- Dramatic printing is automatically disabled when the output stream is piped to a file (e.g. `python my_script.py > output.txt`)
 
 
 Credits

--- a/readme.md
+++ b/readme.md
@@ -174,10 +174,8 @@ dramatic.print("This will print some text dramatically")
 ```
 
 
-Other Features
---------------
-
-Pressing `Ctrl-C` while text is printing dramatically will cause the remaining text to print immediately.
+Dramatic Interpreter
+--------------------
 
 To start a dramatic [Python REPL][]:
 
@@ -204,41 +202,34 @@ In this example we're increasing the speed from 75 characters-per-second to 120:
 ![dramatic module running demo](https://raw.githubusercontent.com/treyhunner/dramatic/main/screenshots/module.gif)
 
 
-Dramatic By Default
--------------------
+Maximum Drama
+-------------
 
 Want to make your Python interpreter dramatic *by default*?
 
-Creating a Python startup file and setting [the `PYTHONSTARTUP` environment variable](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONSTARTUP) to its filename will run some code each time the Python interpreter launches.
-Add this code to your Python startup file to make your Python REPL dramatic by default:
-
-```python
-try:
-    import dramatic, sys
-    sys.__interactivehook__ = dramatic.start
-    del dramatic, sys
-except ImportError:
-    pass
-```
-
-Want to make *every* Python program dramatic?
-You'll need to make a `usercustomize.py` in your user site packages directory.
-Find this directory with:
+Run the `dramatic` module as a script with the `--max-drama` argument to modify Python so that *all* your Python programs will print dramatically:
 
 ```bash
-$ python -c "import site; print(site.getusersitepackages())"
+$ python3 -m dramatic --max-drama
+This will cause all Python programs to run dramatically.
+Running --min-drama will undo this operation.
+Are you sure? [y/N]
 ```
 
-And create a `usercustomize.py` file in that directory, with this in it:
+If the drama is too much, run the module again with the argument `--min-drama` to undo:
 
-```python
-import dramatic, sys
-dramatic.start()
-del dramatic, sys
+```bash
+$ python3 -m dramatic --min-drama
+Deleted file /home/trey/.local/lib/python3.12/site-packages/dramatic.pth
+Deleted file /home/trey/.local/lib/python3.12/site-packages/_dramatic.py
+No drama.
 ```
 
-Note that the `dramatic` module will need to be installed *globally* for this to work.
-To make Python dramatic within virtual environments you'll need to use a `sitecustomize.py` file in your virtual environments "site packages" directory instead.
+
+Other Features
+--------------
+
+Pressing `Ctrl-C` while text is printing dramatically will cause the remaining text to print immediately.
 
 
 Credits


### PR DESCRIPTION
Add `--max-drama` argument (and corresponding `--min-drama`) to ensure all Python programs print dramatically.